### PR TITLE
Pass install command to `cmd` on Windows

### DIFF
--- a/docs/src/cli/install-solana-cli-tools.md
+++ b/docs/src/cli/install-solana-cli-tools.md
@@ -72,7 +72,7 @@ solana --version
   installer into a temporary directory:
 
 ```bash
-curl https://release.solana.com/LATEST_SOLANA_RELEASE_VERSION/solana-install-init-x86_64-pc-windows-msvc.exe --output C:\solana-install-tmp\solana-install-init.exe --create-dirs
+cmd /c "curl https://release.solana.com/LATEST_SOLANA_RELEASE_VERSION/solana-install-init-x86_64-pc-windows-msvc.exe --output C:\solana-install-tmp\solana-install-init.exe --create-dirs"
 ```
 
 - Copy and paste the following command, then press Enter to install the latest


### PR DESCRIPTION
#### Problem
The install instructions for Windows instruct users to open a cmd window and run the install command.
However this is an easy detail to miss, especially since:
- VSCode defaults to PowerShell when opening a new Terminal
- Windows has replaced cmd with PowerShell in the WinX menu (`Win` + `X`, `Win` + `A`)
- New users, especially those without a programming background might not know the difference between shells

PowerShell has a (horrible) feature where it aliases `curl` to `Invoke-Web-Request` inspite of modern Windows versions shipping with curl by default.
This results in a cryptic error message that is hard for new users to debug

```powershell
> curl https://release.solana.com/v1.14.3/solana-install-init-x86_64-pc-windows-msvc.exe `
>> --output C:\solana-install-tmp\solana-install-init.exe --create-dirs

Invoke-WebRequest : A positional parameter cannot be found that accepts argument '--output'.
At line:1 char:1
+ curl https://release.solana.com/v1.14.3/solana-install-init-x86_64-pc ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Invoke-WebRequest], ParameterBindingException
    + FullyQualifiedErrorId : PositionalParameterNotFound,Microsoft.PowerShell.Commands.InvokeWebRequestCommand
```

#### Summary of Changes
A simple solution is to force the command to run under cmd using the `cmd /c` switch.
One side effect is the command will no longer work in POISX emulation shells like Git Bash or MinGW but it is assumed if the user is capable of setting up an alternative shell they know enough fix the issue.